### PR TITLE
Fix bug when not setting FILES_TO_ANALYSE_PATH

### DIFF
--- a/src/mclient/evbuilder.cpp
+++ b/src/mclient/evbuilder.cpp
@@ -928,6 +928,7 @@ int EventBuilder_FileAction(EventBuilder* eb,
 
     FILE* anFiles;
     char fileAnalysis[256];
+    const auto files_to_analyse_path = getenv("FILES_TO_ANALYSE_PATH");
 
     int tt;
 
@@ -939,21 +940,23 @@ int EventBuilder_FileAction(EventBuilder* eb,
             fflush(eb->fout);
             fclose(eb->fout);
 
-            // Adding file to the analysis queue
-            sprintf(fileAnalysis, "%s/%s",
-                    getenv("FILES_TO_ANALYSE_PATH"),
-                    fileNameNow);
+            if (files_to_analyse_path) {
+                // Adding file to the analysis queue
+                sprintf(fileAnalysis, "%s/%s",
+                        files_to_analyse_path,
+                        fileNameNow);
 
-            anFiles = fopen(fileAnalysis, "wt");
-            fclose(anFiles);
+                anFiles = fopen(fileAnalysis, "wt");
+                fclose(anFiles);
 
-            // Adding file to signal the end of the run
-            sprintf(fileAnalysis, "%s/%s",
-                    getenv("FILES_TO_ANALYSE_PATH"),
-                    fileNameEndRun);
+                // Adding file to signal the end of the run
+                sprintf(fileAnalysis, "%s/%s",
+                        files_to_analyse_path,
+                        fileNameEndRun);
 
-            anFiles = fopen(fileAnalysis, "wt");
-            fclose(anFiles);
+                anFiles = fopen(fileAnalysis, "wt");
+                fclose(anFiles);
+            }
 
             eb->fout = (FILE*) nullptr;
 
@@ -978,11 +981,13 @@ int EventBuilder_FileAction(EventBuilder* eb,
             fflush(eb->fout);
             fclose(eb->fout);
 
-            sprintf(fileAnalysis, "%s/%s",
-                    getenv("FILES_TO_ANALYSE_PATH"),
-                    fileNameNow);
-            anFiles = fopen(fileAnalysis, "wt");
-            fclose(anFiles);
+            if (files_to_analyse_path) {
+                sprintf(fileAnalysis, "%s/%s",
+                        files_to_analyse_path,
+                        fileNameNow);
+                anFiles = fopen(fileAnalysis, "wt");
+                fclose(anFiles);
+            }
 
             eb->fout = (FILE*) nullptr;
         }

--- a/src/mclient/evbuilder.cpp
+++ b/src/mclient/evbuilder.cpp
@@ -947,7 +947,12 @@ int EventBuilder_FileAction(EventBuilder* eb,
                         fileNameNow);
 
                 anFiles = fopen(fileAnalysis, "wt");
-                fclose(anFiles);
+                if (anFiles) {
+                    fclose(anFiles);
+                } else {
+                    printf("Error adding file to the analysis queue: %s\n",
+                           fileAnalysis);
+                }
 
                 // Adding file to signal the end of the run
                 sprintf(fileAnalysis, "%s/%s",
@@ -955,7 +960,12 @@ int EventBuilder_FileAction(EventBuilder* eb,
                         fileNameEndRun);
 
                 anFiles = fopen(fileAnalysis, "wt");
-                fclose(anFiles);
+                if (anFiles) {
+                    fclose(anFiles);
+                } else {
+                    printf("Error adding end of run file to the analysis queue: %s\n",
+                           fileAnalysis);
+                }
             }
 
             eb->fout = (FILE*) nullptr;
@@ -986,7 +996,12 @@ int EventBuilder_FileAction(EventBuilder* eb,
                         files_to_analyse_path,
                         fileNameNow);
                 anFiles = fopen(fileAnalysis, "wt");
-                fclose(anFiles);
+                if (anFiles) {
+                    fclose(anFiles);
+                } else {
+                    printf("Error adding file to the analysis queue: %s\n",
+                           fileAnalysis);
+                }
             }
 
             eb->fout = (FILE*) nullptr;


### PR DESCRIPTION
I found the program crashes when opening a new (not the first at start of the acquisition but the next ones if the file gets to file_chunk size) .aqs file if the environment variables FILES_TO_ANALYSE_PATH has not been set. As in PR #24, there is no nullptr checking when getting this environment variable which causes the segmentation fault. 

Also, this should not be like this because the usage of the FILES_TO_ANALYSE_PATH should be optional, as it just serves the purpose of helping further autoanalysis sequences of the files acquired. 

To solve it, I just add a nullptr check for this environment variable. If it is not set, we just skip the code which performs this additional feature.