### PR TITLE
Disable aqs by default

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,7 +133,7 @@ int main(int argc, char** argv) {
     int verbose_level = -1;
     std::string output_directory;
     bool version_flag = false;
-    bool disable_aqs = false;
+    bool enable_aqs = false;
     std::string compression_option = "default";
     double stop_run_after_seconds = 0;
     unsigned int stop_run_after_entries = 0;
@@ -181,7 +181,7 @@ int main(int argc, char** argv) {
 - default: default compression settings, a balance between speed and compression)")
             ->group("File Options")
             ->check(CLI::IsMember(feminos_daq_storage::StorageManager::GetCompressionOptions()));
-    app.add_flag("--disable-aqs", disable_aqs, "Do not store data in aqs format. NOTE: aqs files may be created anyways but they will not have data")->group("File Options");
+    app.add_flag("--enable-aqs", enable_aqs, "Store data in aqs format")->group("File Options");
     app.add_flag("--skip-run-info", skip_run_info, "Skip asking for run information and use default values (same as pressing enter)")->group("General");
 
     CLI11_PARSE(app, argc, argv);
@@ -204,7 +204,7 @@ int main(int argc, char** argv) {
 
     storage_manager.SetOutputDirectory(output_directory);
     storage_manager.compression_option = compression_option;
-    storage_manager.disable_aqs = disable_aqs;
+    storage_manager.disable_aqs = !enable_aqs;
     storage_manager.stop_run_after_seconds = stop_run_after_seconds;
     storage_manager.stop_run_after_entries = stop_run_after_entries;
     storage_manager.allow_losing_events = allow_losing_events;

--- a/src/mclient/evbuilder.cpp
+++ b/src/mclient/evbuilder.cpp
@@ -1110,7 +1110,11 @@ int EventBuilder_FileAction(EventBuilder* eb,
     }
 
     // Open result file
-    if (!(eb->fout = fopen(name, str_res))) {
+    if (storage_manager.disable_aqs) {
+        // If AQS is disabled, we don't open the file
+        eb->fout = nullptr;
+        format = 0; // this will be saved in eb->savedata so that it does not try to write into ACII or AQS files
+    } else if (!(eb->fout = fopen(name, str_res))) {
         printf(
                 "EventBuilder_FileAction: could not open file "
                 "%s.\n",


### PR DESCRIPTION
Address issue #28 

Tasks to do:

- [x] Change CLI option from `disable-aqs` to `enable-aqs`, so aqs is disable by default
- [x] Avoid creation of the .aqs file when is not enabled
- [ ] Save all the information that the .aqs can store in the .root. These are:
    - [ ] Dead time histogram `hbusy`
    - [ ] Pedestal histogram `hped`
    - [ ] Hit count histogram `hhit`

> [!CAUTION]
> DO NOT MERGE! Testing is needed...