### PR TITLE
Get event time from the frame sent by the feminos

### DIFF
--- a/src/root/storage.cpp
+++ b/src/root/storage.cpp
@@ -114,7 +114,7 @@ bool ReadFrame(const std::vector<unsigned short>& frame_data, feminos_daq_storag
 
             if (event.timestamp == 0) {
                 // auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(); // old way
-                auto milliseconds = run_time_start_millis + static_cast<unsigned long long>(time * 1000);
+                auto milliseconds = static_cast<unsigned long long>(time * 1000);
                 event.timestamp = milliseconds;
             }
 
@@ -230,6 +230,7 @@ void StorageManager::Initialize(const string& filename) {
                 if (storage_manager.IsInitialized()) {
 
                     storage_manager.event.id = storage_manager.event_tree->GetEntries();
+                    storage_manager.event.timestamp += storage_manager.run_time_start_millis; // timestamp saved in the frame is relative to the start of the acquisition, so we need to add the run start time
                     storage_manager.event_tree->Fill();
 
                     storage_manager.Checkpoint();


### PR DESCRIPTION
Until now the timestamp of the event is taken from the computer time when reading the frame. This change would get the time from the data frame sent by the feminos. 

The time in the data frame from the feminos is the number of clock ticks (each one is 20ns) since the start of the acquisition. As it was done with the .aqs files, we guess the start of the acquisition is when we open the .aqs/.root file. This should be more precise with just the time difference between the opening of the file and the real time when the feminos starts its clock counting.

I have seen difference of several seconds between the timestamp of an event in the .aqs and its timestamp in the .root file. This can be important in case we want to coordinate with other independent systems...